### PR TITLE
Fix migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## 1. Project Context
 
-This is a **Python 3.12 web scraping project** built with **Scrapy** to extract manga collection data from Whakoom user profiles.
+This is a **Python 3.12 web scraping project** built with **Scrapy** to extract manga collection data from Whakoom user profiles. This is inteded as a hobby yet mantainable project with best practices.
 
 **Core stack:**
 

--- a/README.md
+++ b/README.md
@@ -288,18 +288,12 @@ The project uses a **file-based migration system** with automatic application:
 
 **Migration File Format** (`migrations/XXX_name.sql`):
 ```sql
-# MIGRATION_VERSION
-001
-
-# MIGRATION_NAME
-initial_schema
-
-# UP
+-- Up
 CREATE TABLE lists (...);
 CREATE TABLE titles (...);
 -- ... more tables
 
-# DOWN
+-- Down
 DROP TABLE IF EXISTS lists;
 DROP TABLE IF EXISTS titles;
 -- ... more drops
@@ -308,10 +302,11 @@ DROP TABLE IF EXISTS titles;
 ### How Migrations Work
 
 1. **Load Pending Migrations**: On spider start, `SQLManager` scans `migrations/` directory
-2. **Check Applied**: Compares migration filenames against `migrations` table in DB
-3. **Apply in Order**: Sorts migrations by filename, applies `UP` sections sequentially
-4. **Track Success**: Inserts version + name into `migrations` table
-5. **Rollback Support**: `DOWN` sections defined for potential future rollback (deferred)
+2. **Parse Metadata**: Extracts version and name from filename (e.g., `001_initial_schema.sql` → `001`, `initial_schema`)
+3. **Check Applied**: Compares migration versions against `migrations` table in DB
+4. **Apply in Order**: Sorts migrations by filename, applies `-- Up` sections sequentially
+5. **Track Success**: Automatically inserts version + name into `migrations` table
+6. **Rollback Support**: `-- Down` sections defined for potential future rollback (deferred)
 
 ### Migration Features
 

--- a/whakoom_webscrapper/migrations/001_initial_schema.sql
+++ b/whakoom_webscrapper/migrations/001_initial_schema.sql
@@ -1,7 +1,4 @@
--- MIGRATION_VERSION: 001
--- MIGRATION_NAME: initial_schema
-
--- UP
+-- Up
 CREATE TABLE IF NOT EXISTS lists (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     list_id INTEGER NOT NULL UNIQUE,
@@ -119,9 +116,7 @@ CREATE TABLE IF NOT EXISTS migrations (
     applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
-INSERT INTO migrations (version, name) VALUES ('001', 'initial_schema');
-
--- DOWN
+-- Down
 DROP TABLE IF EXISTS scraping_log;
 DROP TABLE IF EXISTS title_enriched;
 DROP TABLE IF EXISTS title_metadata;


### PR DESCRIPTION

## Summary

Simplifies migration system by extracting version and name from filenames instead of regex-based file content parsing.

## Changes

### Migration File Format
- **Removed**: `-- MIGRATION_VERSION: XXX` header
- **Removed**: `-- MIGRATION_NAME: xxxxx` header  
- **Removed**: Manual `INSERT INTO migrations` statement
- **Changed**: `-- UP` → `-- Up` (case change)
- **Changed**: `-- DOWN` → `-- Down` (case change)

**Old format:**
```sql
-- MIGRATION_VERSION: 001
-- MIGRATION_NAME: initial_schema

-- UP
CREATE TABLE lists (...);

INSERT INTO migrations (version, name) VALUES ('001', 'initial_schema');

-- DOWN
DROP TABLE IF EXISTS lists;
```

**New format:**
```sql
-- Up
CREATE TABLE lists (...);

-- Down
DROP TABLE IF EXISTS lists;
```

### SQLManager Improvements

**Added:**
- `_parse_migration_filename()` - Extracts version and name from filename pattern `XXX_name.sql`
- Full Google docstrings with type annotations
- Strict validation of migration filenames

**Modified:**
- `get_pending_migrations()` - Uses filename-based parsing instead of content regex
  - Raises `RuntimeError` if filename format is invalid
  - Simplified iteration logic without file reading for metadata
- `apply_migrations()` - Updated regex patterns and adds automatic migration record insertion
  - Updated UP regex: `--\s*UP` → `--\s*Up`
  - Updated DOWN regex: `--\s*DOWN` → `--\s*Down`
  - Automatically inserts migration record after successful execution

### Documentation Updates

- Updated README.md migration file format documentation
- Updated "How Migrations Work" section to reflect filename-based metadata extraction

## Benefits

- **Simpler**: No need to maintain duplicate metadata (filename + file content)
- **Less error-prone**: Single source of truth for version and name
- **Stricter validation**: Invalid filenames immediately raise errors
- **Cleaner**: Migration files focus only on SQL logic
- **Conventional**: Follows common migration file naming conventions

## Testing

- Database dropped and recreated successfully
- Migration applied correctly (version: 001, name: initial_schema)
- All 8 expected tables created
- Migrations table automatically populated
- All linting tools passed (ruff, black, bandit, pre-commit)

## Breaking Changes

This is a **breaking change** that requires updating all existing migration files to new format. However, since this project currently has only one migration file, impact is minimal.

Migration files must follow the format: `{3-digit_version}_{description}.sql` (e.g., `001_initial_schema.sql`)